### PR TITLE
Basic TCP between "processes" works

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -1,3 +1,5 @@
 200 400
-1 127.0.0.2 2 
-2 127.0.0.3 3 
+1 localhost 9000 
+2 localhost 9001
+3 localhost 9002
+4 localhost 9003 


### PR DESCRIPTION
## Test

1. Open 2 terminals, do `go run mp1.go 1` in one and `go run mp1.go 2` in the other
2. In the first or second terminal, type `send 2 hello process 2` and it should show up in the second terminal
3. Type `send 1 hello process 1` from the first or second terminal, it should show up in the first terminal

## Info
The messages are sent according to this protocol:
 - The size of the string message (in bytes) is sent as a big endian, signed 32 bit int
 - The sender's PID is sent as a big endian signed 32 bit int
 - ^^ These two ints are the "header"
 - The message is sent as ASCII bytes. The length was sent in the header so the receiver knows how many bytes to expect